### PR TITLE
Use stack for writeMessages

### DIFF
--- a/c++/src/capnp/serialize-async.c++
+++ b/c++/src/capnp/serialize-async.c++
@@ -405,7 +405,7 @@ kj::Promise<void> MessageStream::writeMessages(kj::ArrayPtr<MessageAndFds> messa
 }
 
 kj::Promise<void> MessageStream::writeMessages(kj::ArrayPtr<MessageBuilder*> builders) {
-  auto messages = kj::heapArray<kj::ArrayPtr<const kj::ArrayPtr<const word>>>(builders.size());
+  KJ_STACK_ARRAY(kj::ArrayPtr<const kj::ArrayPtr<const word>>, messages, builders.size(), 16, 256);
   for (auto i : kj::indices(builders)) {
     messages[i] = builders[i]->getSegmentsForOutput();
   }

--- a/c++/src/capnp/serialize-async.c++
+++ b/c++/src/capnp/serialize-async.c++
@@ -358,7 +358,7 @@ kj::Promise<void> writeMessages(
 
 kj::Promise<void> writeMessages(
     kj::AsyncOutputStream& output, kj::ArrayPtr<MessageBuilder*> builders) {
-  auto messages = kj::heapArray<kj::ArrayPtr<const kj::ArrayPtr<const word>>>(builders.size());
+  KJ_STACK_ARRAY(kj::ArrayPtr<const kj::ArrayPtr<const word>>, messages, builders.size(), 16, 256);
   for (auto i : kj::indices(builders)) {
     messages[i] = builders[i]->getSegmentsForOutput();
   }


### PR DESCRIPTION
writeMessagesImpl consumes the array of messages, so we can construct it on the stack.